### PR TITLE
Refactor to use threaded DIP-compliant DiskWorker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ out/production/BadBMTest/edu/touro/mco152/bm/Util.class
 # Ignore Gradle build output directory
 build
 
+
+jdm.properties

--- a/src/main/java/BadBM/App.java
+++ b/src/main/java/BadBM/App.java
@@ -1,7 +1,6 @@
 package BadBM;
 
 import BadBM.persist.DiskRun;
-import BadBM.ui.ConsoleProgram;
 import BadBM.ui.Gui;
 import BadBM.ui.MainFrame;
 import BadBM.ui.SelectFrame;
@@ -279,7 +278,6 @@ public class App {
         worker.start();
         benchmarkStarted = true;
 
-        //programInterface.execute();
     }
 
     public static long targetMarkSizeKb() {

--- a/src/main/java/BadBM/App.java
+++ b/src/main/java/BadBM/App.java
@@ -6,10 +6,8 @@ import BadBM.ui.Gui;
 import BadBM.ui.MainFrame;
 import BadBM.ui.SelectFrame;
 
-import javax.swing.SwingWorker.StateValue;
 import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
-import java.beans.PropertyChangeEvent;
 import java.io.*;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -51,6 +49,7 @@ public class App {
     public static double wMax = -1, wMin = -1, wAvg = -1;
     public static double rMax = -1, rMin = -1, rAvg = -1;
     public static boolean console = false;
+    public static boolean benchmarkStarted = false;
 
     /**
      * @param args the command line arguments
@@ -277,11 +276,8 @@ public class App {
 
         programInterface.addListenerForProperties();
         worker = new DiskWorker(programInterface);
-        try {
-            worker.doBenchmark();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        worker.start();
+        benchmarkStarted = true;
 
         //programInterface.execute();
     }

--- a/src/main/java/BadBM/ConsoleProgram.java
+++ b/src/main/java/BadBM/ConsoleProgram.java
@@ -1,10 +1,11 @@
-package BadBM.ui;
+package BadBM;
 
 import BadBM.DiskMark;
 import BadBM.ProgramInterface;
 
 public class ConsoleProgram implements ProgramInterface {
     int progress = 0;
+    boolean running = false;
     boolean finished = false;
     @Override
     public void runBenchmark() {
@@ -44,6 +45,7 @@ public class ConsoleProgram implements ProgramInterface {
 
     @Override
     public void setRunning(Boolean val) {
+        running = true;
     }
 
     @Override

--- a/src/main/java/BadBM/DiskWorker.java
+++ b/src/main/java/BadBM/DiskWorker.java
@@ -5,7 +5,6 @@ import BadBM.persist.EM;
 import BadBM.ui.Gui;
 
 import javax.persistence.EntityManager;
-import javax.swing.*;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -15,29 +14,23 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static BadBM.App.*;
-import static BadBM.App.programInterface;
 import static BadBM.DiskMark.MarkType.READ;
 import static BadBM.DiskMark.MarkType.WRITE;
 
 /**
- * Run the disk benchmarking as a Swing-compliant thread (only one of these threads can run at
- * once.) Cooperates with Swing to provide and make use of interim and final progress and
- * information, which is also recorded as needed to the persistence store, and log.
+ * Run the disk benchmark. Updates the ProgramInterface Object to allow either GUI or console to show run data
  * <p>
  * Depends on static values that describe the benchmark to be done having been set in App and Gui classes.
  * The DiskRun class is used to keep track of and persist info about each benchmark at a higher level (a run),
- * while the DiskMark class described each iteration's result, which is displayed by the UI as the benchmark run
+ * while the DiskMark class describes each iteration's result, which is displayed by the UI as the benchmark run
  * progresses.
  * <p>
  * This class only knows how to do 'read' or 'write' disk benchmarks. It is instantiated by the
  * startBenchmark() method.
  * <p>
- * To be Swing compliant this class extends SwingWorker and declares that its final return (when
- * doInBackground() is finished) is of type Boolean, and declares that intermediate results are communicated to
- * Swing using an instance of the DiskMark class.
  */
 
-public class DiskWorker extends Thread /*extends SwingWorker<Boolean, DiskMark> */{
+public class DiskWorker extends Thread {
 
     private ProgramInterface programInterface;
 
@@ -55,14 +48,13 @@ public class DiskWorker extends Thread /*extends SwingWorker<Boolean, DiskMark> 
         }
     }
 
-    public Boolean doBenchmark() throws IOException {
-        /**
-     * We 'got here' because: a) End-user clicked 'Start' on the benchmark UI,
-     * which triggered the start-benchmark event associated with the App::startBenchmark()
-     * method.  b) startBenchmark() then instantiated a DiskWorker, and called
-     * its (super class's) execute() method, causing Swing to eventually
-     * call this doInBackground() method.
+    /**
+     * This is the method that runs the essential disk benchmark. It runs in its own thread. It is run by calling
+     * worker.start() from the startBenchmark() method in App(). It feeds progress and results data to a
+     * ProgramInterface object.
      */
+    public Boolean doBenchmark() throws IOException {
+
         programInterface.setRunning(true);
         System.out.println("*** starting new worker thread");
         msg("Running readTest " + App.readTest + "   writeTest " + App.writeTest);
@@ -257,10 +249,8 @@ public class DiskWorker extends Thread /*extends SwingWorker<Boolean, DiskMark> 
             Gui.runPanel.addRun(run);
         }
         App.nextMarkNumber += App.numOfMarks;
-        //System.out.println("Debug Run: " + programInterface.getProgress() + "%");
         programInterface.setRunning(false);
         programInterface.setFinished(true); //needed for console test
-        //System.out.println("we did indeed set finished");
         return true;
     }
 

--- a/src/main/java/BadBM/DiskWorker.java
+++ b/src/main/java/BadBM/DiskWorker.java
@@ -37,7 +37,7 @@ import static BadBM.DiskMark.MarkType.WRITE;
  * Swing using an instance of the DiskMark class.
  */
 
-public class DiskWorker /*extends SwingWorker<Boolean, DiskMark> */{
+public class DiskWorker extends Thread /*extends SwingWorker<Boolean, DiskMark> */{
 
     private ProgramInterface programInterface;
 
@@ -46,7 +46,17 @@ public class DiskWorker /*extends SwingWorker<Boolean, DiskMark> */{
         programInterface.runBenchmark();
     }
 
-    public Boolean doBenchmark() throws IOException {/**
+    @Override
+    public void run() {
+        try {
+            doBenchmark();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Boolean doBenchmark() throws IOException {
+        /**
      * We 'got here' because: a) End-user clicked 'Start' on the benchmark UI,
      * which triggered the start-benchmark event associated with the App::startBenchmark()
      * method.  b) startBenchmark() then instantiated a DiskWorker, and called
@@ -247,7 +257,10 @@ public class DiskWorker /*extends SwingWorker<Boolean, DiskMark> */{
             Gui.runPanel.addRun(run);
         }
         App.nextMarkNumber += App.numOfMarks;
+        //System.out.println("Debug Run: " + programInterface.getProgress() + "%");
         programInterface.setRunning(false);
+        programInterface.setFinished(true); //needed for console test
+        //System.out.println("we did indeed set finished");
         return true;
     }
 

--- a/src/main/java/BadBM/ProgramInterface.java
+++ b/src/main/java/BadBM/ProgramInterface.java
@@ -20,4 +20,10 @@ public interface ProgramInterface {
 
     void setRunning(Boolean val);
 
+    void setFinished(Boolean val);
+
+    boolean getFinished();
+
+    int getProgress();
+
 }

--- a/src/main/java/BadBM/SwingProgram.java
+++ b/src/main/java/BadBM/SwingProgram.java
@@ -16,7 +16,6 @@ public class SwingProgram extends SwingWorker<Boolean, DiskMark> implements Prog
 
     @Override
     public void runBenchmark() {
-
         execute();
     }
 

--- a/src/main/java/BadBM/SwingProgram.java
+++ b/src/main/java/BadBM/SwingProgram.java
@@ -97,6 +97,15 @@ public class SwingProgram extends SwingWorker<Boolean, DiskMark> implements Prog
     }
 
     @Override
+    public void setFinished(Boolean val) {
+    }
+
+    @Override
+    public boolean getFinished() {
+        return false;
+    }
+
+    @Override
     protected void process(List<DiskMark> markList) {
         /**
          * We are passed a list of one or more DiskMark objects that our thread has previously

--- a/src/main/java/BadBM/ui/ConsoleProgram.java
+++ b/src/main/java/BadBM/ui/ConsoleProgram.java
@@ -5,6 +5,7 @@ import BadBM.ProgramInterface;
 
 public class ConsoleProgram implements ProgramInterface {
     int progress = 0;
+    boolean finished = false;
     @Override
     public void runBenchmark() {
     }
@@ -43,6 +44,20 @@ public class ConsoleProgram implements ProgramInterface {
 
     @Override
     public void setRunning(Boolean val) {
+    }
 
+    @Override
+    public void setFinished(Boolean val) {
+        finished = val;
+    }
+
+    @Override
+    public boolean getFinished() {
+        return finished;
+    }
+
+    @Override
+    public int getProgress() {
+        return progress;
     }
 }

--- a/src/test/java/BadBM/ConsoleTest.java
+++ b/src/test/java/BadBM/ConsoleTest.java
@@ -1,16 +1,19 @@
 package BadBM;
 
-import BadBM.ui.ConsoleProgram;
 import BadBM.ui.Gui;
 import BadBM.ui.MainFrame;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsoleTest {
+    private final CountDownLatch waiter = new CountDownLatch(1);
 
     /**
      * Bruteforce setup of static classes/fields to allow DiskWorker to run.
@@ -49,11 +52,21 @@ public class ConsoleTest {
     }
 
     @Test
-    public void consoleTest() throws IOException {
+    public void consoleTest() throws IOException, InterruptedException {
         setupDefaultAsPerProperties();
-        ProgramInterface programInterface = new ConsoleProgram();
-        DiskWorker worker = new DiskWorker(programInterface);
-        Assertions.assertTrue(worker.doBenchmark());
 
+        App.startBenchmark();
+
+        //wait for App.programInterface to be initialized
+        while (!App.benchmarkStarted) {
+            waiter.await(10, TimeUnit.MILLISECONDS);
+        }
+
+        //wait for the benchmark to finish
+        while (!App.programInterface.getFinished()) {
+            waiter.await(10, TimeUnit.MILLISECONDS);
+        }
+
+        assertTrue(App.programInterface.getProgress() >= 100);
     }
 }


### PR DESCRIPTION
This commit fixes the issue with my old implementation of DIP in BadBM by putting the actual benchmark code in its own thread.  I also fixed up some of the comments